### PR TITLE
Prevent accidentally selecting text or images on iOS devices

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -10,6 +10,8 @@
 body {
   background-color: #63462d;
   user-select: none;
+  -webkit-user-select: none; /* prevent text selection on iOS */
+  -webkit-touch-callout: none; /* prevent image selection on iOS */
 }
 
 :root,

--- a/src/modules/Settings/DataTransfer.tsx
+++ b/src/modules/Settings/DataTransfer.tsx
@@ -208,7 +208,12 @@ const ExportData: React.FC<{
 }> = ({ data }) => {
   return (
     <div className="flex flex-col items-center">
-      <img src={data} width={200} height={200} className="[-webkit-touch-callout:default]"></img>
+      <img
+        src={data}
+        width={200}
+        height={200}
+        className="[-webkit-touch-callout:default]"
+      ></img>
       <p className="pt-2 text-sm">
         This image contains all your game data. <strong>Long press</strong> to
         download it and upload it to your new game instance (on another device

--- a/src/modules/Settings/DataTransfer.tsx
+++ b/src/modules/Settings/DataTransfer.tsx
@@ -208,7 +208,7 @@ const ExportData: React.FC<{
 }> = ({ data }) => {
   return (
     <div className="flex flex-col items-center">
-      <img src={data} width={200} height={200}></img>
+      <img src={data} width={200} height={200} className="[-webkit-touch-callout:default]"></img>
       <p className="pt-2 text-sm">
         This image contains all your game data. <strong>Long press</strong> to
         download it and upload it to your new game instance (on another device

--- a/src/modules/Settings/ShareGame.tsx
+++ b/src/modules/Settings/ShareGame.tsx
@@ -12,7 +12,7 @@ const LazyQRCode: FC<{ url: Promise<string> }> = ({ url }) => {
   const dataUrl = use(url);
   return (
     <img
-      className="h-48 w-48 rounded-3xl"
+      className="h-48 w-48 rounded-3xl [-webkit-touch-callout:default]"
       src={dataUrl}
       alt="QR code for sharing the game"
     />


### PR DESCRIPTION
Solution  tested on iPhone 16, iOS 18.3.2

Docs:
https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-touch-callout

Both scenarios:
<img src="https://github.com/user-attachments/assets/c7ded707-ee07-411f-9e8d-f42bd77b8889" style="display:inline" width="25%">
<img src="https://github.com/user-attachments/assets/72329860-676c-4f99-82df-28f8a1981f3b" style="display:inline;" width="25%">
